### PR TITLE
Toml Configurations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "src/toml"]
+	path = src/toml
+	url = https://github.com/FeTetra/badtoml
+	branch = ps3-sdk-compat

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ SRC_DIRS = \
 	$(SRC_DIR) \
 	$(SRC_DIR)/tools \
 	$(SRC_DIR)/hooks \
+	$(SRC_DIR)/toml \
 
 PRX_TARGET = patchwork.prx
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -1,0 +1,22 @@
+#ifndef GLOBALS_H
+#define GLOBALS_H
+
+#define STR1(x)  #x
+#define STR(x)  STR1(x)
+
+#define MAIN_CONFIG_PATH "/dev_hdd0/plugins/patchwork/patchwork.toml"
+#define MAIN_CONFIG_SECTION "patchwork"
+
+#define SUCCESS_MESSAGE_WITH_PW "/popup.ps3?Patchwork%20"STR(PATCHWORK_VERSION_MAJOR)"."STR(PATCHWORK_VERSION_MINOR)"%20Loaded%20for%20LBP2%0ALobby%20password%20has%20been%20set&icon=8&snd=5"
+#define SUCCESS_MESSAGE_RANDOM_PW "/popup.ps3?Patchwork%20"STR(PATCHWORK_VERSION_MAJOR)"."STR(PATCHWORK_VERSION_MINOR)"%20Loaded%20for%20LBP2%0ALobby%20password%20has%20been%20randomized&icon=8&snd=5"
+#define SUCCESS_MESSAGE_WITHOUT_PW "/popup.ps3?Patchwork%20"STR(PATCHWORK_VERSION_MAJOR)"."STR(PATCHWORK_VERSION_MINOR)"%20Loaded%20for%20LBP2%0ALobby%20password%20is%20disabled&icon=8&snd=5"
+
+// Not reallyyy used right now, but could be useful later
+enum GameNumber {
+    GAME_LBP1 = 1,
+    GAME_LBP2 = 2,
+    GAME_LBP3 = 3,
+    GAME_LBP3_JP = 4,
+};
+
+#endif //GLOBALS_H

--- a/src/patchwork.toml
+++ b/src/patchwork.toml
@@ -1,0 +1,6 @@
+# This is an example of the main configuration
+[patchwork]
+server_url = "http://lbp.lbpbonsai.com/lbp"
+digest_key = "CustomServerDigest"
+join_key = "password123"
+enable_join_key = true

--- a/src/prx.c
+++ b/src/prx.c
@@ -1,77 +1,67 @@
 #include <sys/prx.h>
-#include <sys/process.h>
 #include <sys/sys_time.h>
 
 #include <cell/hash/libsha256.h>
 #include <cell/sysmodule.h>
 
 #include "hooks/hooks.h"
-#include "tools/memory.h"
+#include "hooks/script-block.h"
 #include "tools/util.h"
 #include "tools/fs.h"
 #include "offsets.h"
-#include "hooks/script-block.h"
+#include "globals.h"
 
-#define STR1(x)  #x
-#define STR(x)  STR1(x)
+#include "toml/toml.h"
+#include "toml/keymap.h"
+#include "toml/tokenizer.h"
 
 SYS_MODULE_INFO(PatchworkLBP, 0, PATCHWORK_VERSION_MAJOR, PATCHWORK_VERSION_MINOR);
 SYS_MODULE_START(start);
 
-#define LOBBY_PASSWORD_PATH "/dev_hdd0/plugins/patchwork/patchwork_lobby_password.txt"
-#define GAME_URL_PATH "/dev_hdd0/plugins/patchwork/patchwork_url.txt"
-#define DIGEST_PATH "/dev_hdd0/plugins/patchwork/patchwork_digest.txt"
-
-#define SUCCESS_MESSAGE_WITH_PW "/popup.ps3?Patchwork%20"STR(PATCHWORK_VERSION_MAJOR)"."STR(PATCHWORK_VERSION_MINOR)"%20Loaded%20for%20LBP2%0ALobby%20password%20has%20been%20set&icon=8&snd=5"
-#define SUCCESS_MESSAGE_WITHOUT_PW "/popup.ps3?Patchwork%20"STR(PATCHWORK_VERSION_MAJOR)"."STR(PATCHWORK_VERSION_MINOR)"%20Loaded%20for%20LBP2%0ALobby%20password%20has%20been%20randomized&icon=8&snd=5"
-
-// Not reallyyy used right now, but could be useful later
-enum GameNumber {
-    GAME_LBP1 = 1,
-    GAME_LBP2 = 2,
-    GAME_LBP3 = 3,
-    GAME_LBP3_JP = 4,
-};
-
 int start(void);
 int start(void)
 {
-    const sys_pid_t process_pid = sys_process_getpid();
-
     cellSysmoduleLoadModule(CELL_SYSMODULE_FS);
 
-    int password_randomized = 1;
+    char toml_buf[256];
+    ReadFile(MAIN_CONFIG_PATH, toml_buf, 256);
+
+    Lexer l = MakeLexer(toml_buf);
+    TOMLEntry entries[4];
+    TOMLReadBuffer(&l, entries, 4);
+
+    char *server_url = NULL;
+    char *join_key = NULL;
+    char *digest_key = NULL;
+    int enable_join_key = 1;
+
+    TOMLKeyMap key_map[] = {
+        {MAIN_CONFIG_SECTION, "server_url", TOML_TYPE_STRING, &server_url},
+        {MAIN_CONFIG_SECTION, "join_key", TOML_TYPE_STRING, &join_key},
+        {MAIN_CONFIG_SECTION, "digest_key", TOML_TYPE_STRING, &digest_key},
+        {MAIN_CONFIG_SECTION, "enable_join_key", TOML_TYPE_BOOL, &enable_join_key},
+    };
+
+    TOMLApplyEntriesToKeyMap(entries, 4, key_map, 4);
 
     unsigned char xxtea_key[32];
-    char *lobby_password = __builtin_alloca(16);
-	memset(lobby_password, 0, 16);
-    const int read_password = ReadFile(LOBBY_PASSWORD_PATH, lobby_password, 16);
+    int join_key_randomized = 1;
 
-    if (read_password) {
-		lobby_password = TrimEnd(lobby_password);
-        // Hash the lobby password so we get an unrecoverable string of a fixed length
-        cellSha256Digest(lobby_password, strlen(lobby_password), xxtea_key);
-        password_randomized = 0;
-    } else {
-        // Generate random key
-        sys_time_sec_t sec = 0;
-        sys_time_nsec_t nsec = 0;
-        sys_time_get_current_time(&sec, &nsec);
-        uint64_t combined_time = nsec + sec;
-        cellSha256Digest(&combined_time, sizeof(uint64_t), xxtea_key);
+    if (enable_join_key) {
+        if (join_key) {
+            join_key = TrimEnd(join_key);
+            // Hash the lobby password so we get an unrecoverable string of a fixed length
+            cellSha256Digest(join_key, strlen(join_key), xxtea_key);
+            join_key_randomized = 0;
+        } else {
+            // Generate random key
+            sys_time_sec_t sec = 0;
+            sys_time_nsec_t nsec = 0;
+            sys_time_get_current_time(&sec, &nsec);
+            uint64_t combined_time = nsec + sec;
+            cellSha256Digest(&combined_time, sizeof(uint64_t), xxtea_key);
+        }
     }
-    
-    char *url = __builtin_alloca(70);
-	memset(url, 0, 70);
-    const int read_url = ReadFile(GAME_URL_PATH, url, 70);
-
-    if(read_url) url = TrimEnd(url);
-
-    char *digest = __builtin_alloca(LBP_DIGEST_LENGTH);
-	memset(digest, 0, LBP_DIGEST_LENGTH);
-    const int read_digest = ReadFile(DIGEST_PATH, digest, LBP_DIGEST_LENGTH);
-	
-	if(read_digest) digest = TrimEnd(digest);
 
     char *user_agent;
 
@@ -153,8 +143,12 @@ int start(void)
     } else {
         char *msgBuf = __builtin_alloca(sizeof(SUCCESS_MESSAGE_WITHOUT_PW));
 
-        if (password_randomized == 0) {
-            strcpy(msgBuf, SUCCESS_MESSAGE_WITH_PW);
+        if (enable_join_key) {
+            if (!join_key_randomized) {
+                strcpy(msgBuf, SUCCESS_MESSAGE_WITH_PW);
+            } else {
+                strcpy(msgBuf, SUCCESS_MESSAGE_RANDOM_PW);
+            }
         } else {
             strcpy(msgBuf, SUCCESS_MESSAGE_WITHOUT_PW);
         }
@@ -162,28 +156,34 @@ int start(void)
         WriteFile("/dev_hdd0/tmp/wm_request", msgBuf, strlen(msgBuf));
     }
 
-    size_t url_len = strlen(url) + 1;
+    size_t url_len = 0;
+    if(server_url) {
+        server_url = TrimEnd(server_url);
+        url_len = strlen(server_url) + 1;
+    }
 
     // Write to the chosen offets
-    if (network_key_offset)
-        WriteProcessMemory(process_pid, network_key_offset, xxtea_key, LBP_NETWORK_KEY_SIZE);
+    if (enable_join_key && network_key_offset)
+        memcpy(network_key_offset, xxtea_key, LBP_NETWORK_KEY_SIZE);
     if (user_agent_offset)
-        WriteProcessMemory(process_pid, user_agent_offset, user_agent, strlen(user_agent) + 1);
-    if (https_url_offset && url[0])
-        WriteProcessMemory(process_pid, https_url_offset, url, url_len);
-    if (http_url_offset && url[0])
-        WriteProcessMemory(process_pid, http_url_offset, url, url_len);
-    if (digest_offset && digest[0])
-        WriteProcessMemory(process_pid, digest_offset, digest, LBP_DIGEST_LENGTH);
-    if (presence_url_offset && url[0])
-        WriteProcessMemory(process_pid, presence_url_offset, url, url_len);
-    if (live_url_offset && url[0])
-        WriteProcessMemory(process_pid, live_url_offset, url, url_len);
+        memcpy(user_agent_offset, user_agent, strlen(user_agent) + 1);
+    if (https_url_offset && server_url)
+        memcpy(https_url_offset, server_url, url_len);
+    if (http_url_offset && server_url)
+        memcpy(http_url_offset, server_url, url_len);
+    if (digest_offset && digest_key) {
+        digest_key = TrimEnd(digest_key);
+        memcpy(digest_offset, digest_key, LBP_DIGEST_LENGTH);
+    }
+    if (presence_url_offset && server_url)
+        memcpy(presence_url_offset, server_url, url_len);
+    if (live_url_offset && server_url)
+        memcpy(live_url_offset, server_url, url_len);
     if (notification_enable_offset && notification_enable_instr)
-        *(uint32_t *)notification_enable_offset = notification_enable_instr;
+        memcpy(notification_enable_offset, &notification_enable_instr, 4);
     if (rescheck_offset && rescheck_hook) {
         uint32_t rescheck_instr = RelativeBranch(rescheck_hook, rescheck_offset);
-        WriteProcessMemory(process_pid, rescheck_offset, &rescheck_instr, 4);
+        memcpy(rescheck_offset, &rescheck_instr, 4);
     }
 
     // Exit


### PR DESCRIPTION
This PR implements using a TOML file as a configuration instead of using individual files per configurable option. 

This also changes memory writes to use `memcpy()` instead of `WriteProcessMemory()`, this will need more testing to ensure stability on all games for CFW and PS3HEN, but it seems to work alright.